### PR TITLE
feat: add multi platform container build support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,15 @@ LABEL maintainer="Doğukan Çağatay <dcagatay@gmail.com>"
 ARG MKCERT_VERSION="v1.4.4"
 ARG GITHUB_PROXY="https://github.com"
 
-ENV DOMAINS="dev.mydomain.com"
-
-ADD ${GITHUB_PROXY}/FiloSottile/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-amd64 /usr/bin/mkcert
+ARG TARGETOS
+ARG TARGETARCH
+ADD ${GITHUB_PROXY}/FiloSottile/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-$TARGETOS-$TARGETARCH /usr/bin/mkcert
 COPY ./entrypoint.sh /entrypoint.sh
+RUN chmod +x /usr/bin/mkcert /entrypoint.sh
 
-WORKDIR /root/.local/share/mkcert
+# Put CA certificates under /certs/ca
+ENV CAROOT="/certs/ca"
 
-RUN chmod +x /usr/bin/mkcert /entrypoint.sh && \
-    ln -s /root/.local/share/mkcert /certs
-
+WORKDIR /certs
+VOLUME /certs
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 The container can be run with *docker run* command and create a new Root CA certificate and a single certificate for our domain list.
 
 ```sh
-docker run --rm -it -v "$PWD/certs:/certs" dcagatay/mkcert example.com www.example.com *.example.com
+docker run --rm -it -v "$PWD/certs:/certs" dcagatay/mkcert example.com www.example.com '*.example.com'
 ```
 
 If the domain list is not given, only Root CA certificate will be created.
@@ -18,16 +18,29 @@ If the domain list is not given, only Root CA certificate will be created.
 docker run --rm -it -v "$PWD/certs:/certs" dcagatay/mkcert
 ```
 
-If a Root CA certificate exists in volume-mapped `/certs` directory (`/certs/rootCA.pem` and `/certs/rootCA-key.pem`, the certificate will be created using that Root CA certificate.
+If a Root CA certificate exists `/certs/ca` directory (`/certs/ca/rootCA.pem` and `/certs/ca/rootCA-key.pem`, the certificate will be created using that Root CA certificate.
 
 ### Advanced Usage
 
-The owner of the created certificates is *root* user by default. If you want to change the ownership of the certificates you can provide `UID` and `GID` environment variables to the command.
+The owner of the created certificates is *root* user by default. If you want to change the ownership of the certificates you can provide `PUID` and `PGID` environment variables to the command.
 
 ```sh
-docker run --rm -it -e "UID=1000" -e "GID=1000" -v "$PWD/certs:/certs" dcagatay/mkcert example.com www.example.com *.example.com
+docker run --rm -it -e "PUID=$(id -u)" -e "PGID=$(id -g)" -v "$PWD/certs:/certs" dcagatay/mkcert example.com www.example.com '*.example.com'
 ```
 
+## Building Image Locally
+
+```sh
+docker buildx build -t dcagatay/mkcert:latest .
+```
+
+## Changelog
+
+- In the version `v1.4.4`;
+  - The root certificate directory was moved to `/certs/ca` from `/certs`, If you were using a previous version you need to move your `rootCA.pem` and `rootCA-key.pem` files under `/certs/ca`.
+  - The user id and group id variables, `UID` and `GID`, are renamed to `PUID` and `PGUID`.
+
 ## Credits
+
 - [FiloSottile/mkcert](https://github.com/FiloSottile/mkcert)
 - Inspired by [vishnudxb/docker-mkcert](https://github.com/vishnudxb/docker-mkcert)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 
-# set -x
+set -e
 
 if [ -z "$@" ]; then
   mkcert -install
 else
-  mkcert -install && mkcert $@
+  mkcert -install && mkcert "$@"
 fi
 
-if [ ! -z "$UID" ] && [ ! -z "$GID" ]; then
-  chown -R "$UID:$GID" /certs/*
+if [ -n "${PUID}" ] && [ -n "${PGID}" ]; then
+  chown -R "$PUID:$PGID" /certs
 fi


### PR DESCRIPTION
Multi container build support added to the included Dockerfile.
Currently the it is only tested with docker daemon and can be build with
buildkit.
