### PR TITLE
ci: add multi platform multi branch build to ci

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,45 +1,56 @@
-name: Publish Docker image
+name: Build and publish container image
 
 on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
   release:
     types: [published]
 
 env:
   image_name: "dcagatay/mkcert"
+  build_platforms: "linux/amd64,linux/arm64,linux/arm/v7"
 
 jobs:
-  bake-latest:
+  build-and-push:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract variables
-        id: variables
-        run: |
-          echo ::set-output name=SOURCE_NAME::${GITHUB_REF#refs/*/}
-          echo ::set-output name=SOURCE_BRANCH::${GITHUB_REF#refs/heads/}
-          echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        if: github.event_name == 'release'
+        uses: docker/build-push-action@v6
         with:
-          context: .
           push: true
+          platforms: ${{ env.build_platforms }}
           tags: |
-            ${{ env.image_name }}:latest,${{ env.image_name }}:${{ steps.variables.outputs.SOURCE_TAG }}
+            ${{ env.image_name }}:latest,${{ env.image_name }}:${{ github.ref_name }}
           build-args: |
-            MKCERT_VERSION=${{ steps.variables.outputs.SOURCE_TAG }}
+            MKCERT_VERSION=${{ github.ref_name }}
+
+      - name: Build and push branches
+        id: docker_master_build
+        if: github.event_name != 'release'
+        uses: docker/build-push-action@v6
+        with:
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          platforms: ${{ env.build_platforms }}
+          tags: |
+            ${{ env.image_name }}:master


### PR DESCRIPTION
Multi platform container build and push was added along with multi
branch build to the gh actions.

The builds are started for each release, pr and `master` push. The release
and `master` branch push builds are uploaded to the container registry.
